### PR TITLE
nvmetcli: 'discovery_nqn' configfs attribute

### DIFF
--- a/nvmet/nvme.py
+++ b/nvmet/nvme.py
@@ -234,6 +234,7 @@ class Root(CFSNode):
     def __init__(self):
         super(Root, self).__init__()
 
+        self.attr_groups = ['discovery']
         if not os.path.isdir(self.configfs_dir):
             self._modprobe('nvmet')
 

--- a/nvmetcli
+++ b/nvmetcli
@@ -94,9 +94,17 @@ class UINode(configshell.node.ConfigNode):
 
 
 class UIRootNode(UINode):
+    ui_desc_discovery = {
+        'nqn': ('string', 'Discovery NQN'),
+    }
     def __init__(self, shell):
         UINode.__init__(self, '/', parent=None, cfnode=nvme.Root(),
                         shell=shell)
+
+    def summary(self):
+        info = []
+        info.append("discovery=" + self.cfnode.get_attr("discovery", "nqn"))
+        return (", ".join(info), True)
 
     def refresh(self):
         self._children = set([])


### PR DESCRIPTION
Implement support for the 'discovery_nqn' configfs attribute to allow the user to read or modify the persistent discovery NQN.